### PR TITLE
implement optional ip adresses

### DIFF
--- a/lib/servers/publicNetwork.js
+++ b/lib/servers/publicNetwork.js
@@ -7,13 +7,15 @@ class PublicNetwork {
 
     // IPv4
     const ipv4 = publicNet.ipv4
-    this.ipv4 = new Address(ipv4.ip, ipv4.dns_ptr, ipv4.blocked,
-      (ip, pointer) => this.server.endpoint.actions.changeDnsPointer(this.server.id, ip, pointer))
+    if (ipv4)
+      this.ipv4 = new Address(ipv4.ip, ipv4.dns_ptr, ipv4.blocked,
+        (ip, pointer) => this.server.endpoint.actions.changeDnsPointer(this.server.id, ip, pointer))
 
     // IPv6
     const ipv6 = publicNet.ipv6
-    this.ipv6 = new AddressBlock(ipv6.ip, ipv6.dns_ptr, ipv6.blocked,
-      (ip, pointer) => this.server.endpoint.actions.changeDnsPointer(this.server.id, ip, pointer))
+    if (ipv6)
+      this.ipv6 = new AddressBlock(ipv6.ip, ipv6.dns_ptr, ipv6.blocked,
+        (ip, pointer) => this.server.endpoint.actions.changeDnsPointer(this.server.id, ip, pointer))
 
     this.floatingIPs = publicNet.floating_ips
   }


### PR DESCRIPTION
HCloud supports having servers with no ipv4/ipv6 respectively now.